### PR TITLE
[FENG 1723] Improve troubleshooting exercises

### DIFF
--- a/troubleshooting/checkpointing/src/main/java/com/ververica/flink/training/exercises/CheckpointingJob.java
+++ b/troubleshooting/checkpointing/src/main/java/com/ververica/flink/training/exercises/CheckpointingJob.java
@@ -176,12 +176,14 @@ public class CheckpointingJob {
             long eventsPerWindow = 0L;
             double sumPerWindow = 0.0;
 
+            double diffPerMeasurement;
             Measurement previous = null;
             while (!windowedMeasurements.isEmpty()) {
                 Tuple2<Measurement, Long> measurement = windowedMeasurements.poll();
                 ++eventsPerWindow;
                 if (previous != null) {
-                    sumPerWindow += measurement.f0.getValue() - previous.getValue();
+                    diffPerMeasurement = measurement.f0.getValue() - previous.getValue();
+                    sumPerWindow += diffPerMeasurement * diffPerMeasurement;
                 }
                 previous = measurement.f0;
             }

--- a/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution2.java
+++ b/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution2.java
@@ -169,11 +169,14 @@ public class CheckpointingJobSolution2 {
 
             long eventsPerWindow = 0L;
             double sumPerWindow = 0.0;
+
+            double diffPerMeasurement;
             Measurement previous = null;
             for (Tuple2<Measurement, Long> measurement : list) {
                 ++eventsPerWindow;
                 if (previous != null) {
-                    sumPerWindow += measurement.f0.getValue() - previous.getValue();
+                    diffPerMeasurement = measurement.f0.getValue() - previous.getValue();
+                    sumPerWindow += diffPerMeasurement * diffPerMeasurement;
                 }
                 previous = measurement.f0;
             }

--- a/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution3.java
+++ b/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution3.java
@@ -193,8 +193,10 @@ public class CheckpointingJobSolution3 {
         public Tuple3<Long, Double, Double> add(
                 final Measurement record, final Tuple3<Long, Double, Double> aggregate) {
 
+            double diffPerMeasurement;
             if (aggregate.f0 > 0) {
-                aggregate.f1 += record.getValue() - aggregate.f2;
+                diffPerMeasurement = record.getValue() - aggregate.f2;
+                aggregate.f1 += diffPerMeasurement * diffPerMeasurement;
             }
             aggregate.f0++;
             aggregate.f2 = record.getValue();

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution12.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution12.java
@@ -1,0 +1,235 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job evolved on top of {@link
+ * com.ververica.flink.training.exercises.TroubledStreamingJob} by fixing job crashes due to parsing
+ * errors.
+ */
+public class TroubledStreamingJobSolution12 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+     *
+     * @throws Exception if the application is misconfigured or fails during job submission
+     */
+    public static void main(String[] args) throws Exception {
+        ParameterTool parameters = ParameterTool.fromArgs(args);
+
+        StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+        // Timing Configuration
+        env.getConfig().setAutoWatermarkInterval(2000);
+
+        // Checkpointing Configuration
+        env.enableCheckpointing(5000);
+        env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+        DataStream<FakeKafkaRecord> sourceStream =
+                env.addSource(SourceUtils.createFakeKafkaSource())
+                        .name("FakeKafkaSource")
+                        .uid("FakeKafkaSource")
+                        .assignTimestampsAndWatermarks(new MeasurementTSExtractor())
+                        .name("Watermarks")
+                        .uid("Watermarks");
+
+        OutputTag<FakeKafkaRecord> dirtyDataTag =
+                new OutputTag<FakeKafkaRecord>("dirty-data") {
+                    private static final long serialVersionUID = 33513631677208956L;
+                };
+
+        SingleOutputStreamOperator<JsonNode> parsedStream =
+                sourceStream
+                        .process(new MeasurementDeserializer(dirtyDataTag))
+                        .name("Deserialization")
+                        .uid("Deserialization");
+
+        OutputTag<JsonNode> lateDataTag =
+                new OutputTag<JsonNode>("late-data") {
+                    private static final long serialVersionUID = 33513631677208956L;
+                };
+
+        SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation =
+                parsedStream
+                        .keyBy(jsonNode -> jsonNode.get("location").asText())
+                        .window(TumblingEventTimeWindows.of(Time.seconds(1)))
+                        .sideOutputLateData(lateDataTag)
+                        .process(new MeasurementWindowAggregatingFunction())
+                        .name("WindowedAggregationPerLocation")
+                        .uid("WindowedAggregationPerLocation");
+
+        if (isLocal(parameters)) {
+            parsedStream
+                    .getSideOutput(dirtyDataTag)
+                    .printToErr()
+                    .name("DirtyDataSink")
+                    .uid("DirtyDataSink")
+                    .disableChaining();
+            aggregatedPerLocation
+                    .print()
+                    .name("NormalOutput")
+                    .uid("NormalOutput")
+                    .disableChaining();
+            aggregatedPerLocation
+                    .getSideOutput(lateDataTag)
+                    .printToErr()
+                    .name("LateDataSink")
+                    .uid("LateDataSink")
+                    .disableChaining();
+        } else {
+            parsedStream
+                    .getSideOutput(dirtyDataTag)
+                    .addSink(new DiscardingSink<>())
+                    .name("DirtyDataSink")
+                    .uid("DirtyDataSink")
+                    .disableChaining();
+            aggregatedPerLocation
+                    .addSink(new DiscardingSink<>())
+                    .name("NormalOutput")
+                    .uid("NormalOutput")
+                    .disableChaining();
+            aggregatedPerLocation
+                    .getSideOutput(lateDataTag)
+                    .addSink(new DiscardingSink<>())
+                    .name("LateDataSink")
+                    .uid("LateDataSink")
+                    .disableChaining();
+        }
+
+        env.execute(TroubledStreamingJobSolution12.class.getSimpleName());
+    }
+
+    /** Deserializes the JSON Kafka message. */
+    public static class MeasurementDeserializer extends ProcessFunction<FakeKafkaRecord, JsonNode> {
+        private static final long serialVersionUID = 2L;
+
+        private Counter numInvalidRecords;
+        private OutputTag<FakeKafkaRecord> dirtyDataTag;
+
+        /**
+         * Initializes the deserializer with the output tag for the dirty data side output.
+         *
+         * @param dirtyDataTag output tag to redirect for broken input records
+         */
+        public MeasurementDeserializer(final OutputTag<FakeKafkaRecord> dirtyDataTag) {
+            super();
+            this.dirtyDataTag = dirtyDataTag;
+        }
+
+        @Override
+        public void open(final Configuration parameters) throws Exception {
+            super.open(parameters);
+            numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+        }
+
+        @Override
+        public void processElement(
+                final FakeKafkaRecord kafkaRecord,
+                final ProcessFunction<FakeKafkaRecord, JsonNode>.Context ctx,
+                final Collector<JsonNode> out) {
+            try {
+                out.collect(deserialize(kafkaRecord.getValue()));
+            } catch (IOException e) {
+                numInvalidRecords.inc();
+                ctx.output(dirtyDataTag, kafkaRecord);
+            }
+        }
+
+        private JsonNode deserialize(final byte[] bytes) throws IOException {
+            return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
+        }
+    }
+
+    public static class MeasurementTSExtractor
+            extends BoundedOutOfOrdernessTimestampExtractor<FakeKafkaRecord> {
+        private static final long serialVersionUID = 1L;
+
+        MeasurementTSExtractor() {
+            super(Time.of(250, TimeUnit.MILLISECONDS));
+        }
+
+        @Override
+        public long extractTimestamp(final FakeKafkaRecord record) {
+            return record.getTimestamp();
+        }
+    }
+
+    public static class MeasurementWindowAggregatingFunction
+            extends ProcessWindowFunction<JsonNode, WindowedMeasurements, String, TimeWindow> {
+        private static final long serialVersionUID = 1L;
+
+        private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+        private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+        @Override
+        public void process(
+                final String location,
+                final Context context,
+                final Iterable<JsonNode> input,
+                final Collector<WindowedMeasurements> out) {
+
+            WindowedMeasurements aggregate = new WindowedMeasurements();
+            for (JsonNode record : input) {
+                double result = Double.parseDouble(record.get("value").asText());
+                aggregate.addMeasurement(result);
+            }
+
+            final TimeWindow window = context.window();
+            aggregate.setWindow(window);
+            aggregate.setLocation(location);
+
+            eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+            out.collect(aggregate);
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            super.open(parameters);
+
+            eventTimeLag =
+                    getRuntimeContext()
+                            .getMetricGroup()
+                            .histogram(
+                                    "eventTimeLag",
+                                    new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+        }
+    }
+
+    private static class ObjectMapperSingleton {
+        static ObjectMapper getInstance() {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            return objectMapper;
+        }
+    }
+}


### PR DESCRIPTION
I have added one more solution to the troubleshooting introduction exercise which shows how to redirect corrupted input to a side output

I only have changed the sumPerWindow calculation to accumulate the square of the differences between the consequent measurements in order not to change the structure of the WindowedMeasurements class